### PR TITLE
helloworld.erl

### DIFF
--- a/helloworld.erl
+++ b/helloworld.erl
@@ -1,0 +1,5 @@
+-module(helloworld).
+-export([start/0]).
+
+start() ->
+    io:format("Hello, World!~n").


### PR DESCRIPTION
Explanation:
-module(helloworld).: Declares the name of the module, which should match the filename (in this case, helloworld.erl).
-export([start/0]).: Exports the start function, which takes 0 arguments (/0 means zero arguments), allowing it to be called from outside the module.
start() -> io:format("Hello, World!~n").: This defines the start function, which prints "Hello, World!" to the console. ~n is used to insert a newline.